### PR TITLE
FIX : GetNextHappenings.cs, ChoiceManager.cs

### DIFF
--- a/Assets/02. Scripts/ChoiceSystem/ChoiceManager.cs
+++ b/Assets/02. Scripts/ChoiceSystem/ChoiceManager.cs
@@ -44,7 +44,7 @@ public class ChoiceManager : MonoBehaviour
     public Animator anim; // 창 열리고 닫히는 애니메이션 동작
 
     public bool choiceIng; // 선택지 대기, 다음 대화로 넘어가지 않게
-    //private bool keyInput; // 키처리 활성화, 비활성화, 키 입력이 없기때문에 제거하였음.
+    private bool clickAvailable; // 선택지 선택 활성화/비활성화, 선택지가 다 나오지 않았을 때 선택지 버튼을 클릭하는걸 막기 위해 사용
 
     private int count; // 배열의 크기
     private int result; // 선택지 선택 결과, 0~4
@@ -62,6 +62,7 @@ public class ChoiceManager : MonoBehaviour
             answerPanel[i].SetActive(false);
         }
         questionText.text = "";
+        clickAvailable = false;
     }
     
     // ANCHOR Utils (Set_question, Add_answerList, GetResult, SetResult)
@@ -113,6 +114,7 @@ public class ChoiceManager : MonoBehaviour
 
         anim.SetBool("Appear", true);
         //Selection(); // result 초기화에 따른 변경
+        clickAvailable = false;
         StartCoroutine(ChoiceCoroutine());
     }
 
@@ -175,8 +177,6 @@ public class ChoiceManager : MonoBehaviour
             StartCoroutine(TypingAnswer4());
         }
         yield return new WaitForSeconds(0.5f);
-
-        //keyInput = true;
     }
     // 코루틴 하나로 다돌리면 문제 생긴다고 함.
     // 그래서 여러개로 나누어서 한번에 실행?한다고 함
@@ -196,6 +196,7 @@ public class ChoiceManager : MonoBehaviour
             answerText[type].text += answerList[type][i];
             yield return waitTime;
         }
+        if(count == 0)clickAvailable = true;
     }
     IEnumerator TypingAnswer1(int type = 1)
     {
@@ -205,6 +206,7 @@ public class ChoiceManager : MonoBehaviour
             answerText[type].text += answerList[type][i];
             yield return waitTime;
         }
+        if(count == 1)clickAvailable = true;
     }
     IEnumerator TypingAnswer2(int type = 2)
     {
@@ -214,6 +216,7 @@ public class ChoiceManager : MonoBehaviour
             answerText[type].text += answerList[type][i];
             yield return waitTime;
         }
+        if(count == 2)clickAvailable = true;
     }
     IEnumerator TypingAnswer3(int type = 3)
     {
@@ -223,6 +226,7 @@ public class ChoiceManager : MonoBehaviour
             answerText[type].text += answerList[type][i];
             yield return waitTime;
         }
+        if(count == 3)clickAvailable = true;
     }
     IEnumerator TypingAnswer4(int type = 4)
     {
@@ -232,6 +236,7 @@ public class ChoiceManager : MonoBehaviour
             answerText[type].text += answerList[type][i];
             yield return waitTime;
         }
+        if(count == 4)clickAvailable = true;
     }
 
 
@@ -241,7 +246,7 @@ public class ChoiceManager : MonoBehaviour
     /// 지금은 버튼을 마우스를 통해 클릭하기 때문에 제거하였음.
     /// </summary>
     // private void Update() {
-    //     if(keyInput){
+    //     if(clickAvailable){
     //         if(Input.GetKeyDown(KeyCode.UpArrow)){
     //             if(result > 0)result--;
     //             else result = 0;
@@ -253,7 +258,7 @@ public class ChoiceManager : MonoBehaviour
     //             //Selection();
     //         }
     //         else if(Input.GetKeyDown(KeyCode.Z)){
-    //             keyInput = false;
+    //             clickAvailable = false;
     //             ExitChoice();
     //         }
     //     }
@@ -283,8 +288,9 @@ public class ChoiceManager : MonoBehaviour
     /// </summary>
     /// <param name="what">선택지 버튼 idx</param>
     public void CatchClick(int what){
+        if(!clickAvailable)return;
         result = what;
-        //keyInput = false;
+        clickAvailable = false;
         ExitChoice();
     }
 }

--- a/Assets/02. Scripts/HappeningOccur/GetNextHappening.cs
+++ b/Assets/02. Scripts/HappeningOccur/GetNextHappening.cs
@@ -191,6 +191,7 @@ public class GetNextHappening : MonoBehaviour
                     int count = int.Parse(happeningsTxtScripts.ReadLine());
 
                     // 선택지 텍스트 채우기
+                    ChoiceManager.instance.Clear_answerList(); // IndexOutOfRange 에러 해결 코드
                     for (int i = 0; i < count; i++)
                     {
                         ChoiceManager.instance.Add_answerList(happeningsTxtScripts.ReadLine());

--- a/Assets/02. Scripts/HappeningOccur/GetNextHappening.cs
+++ b/Assets/02. Scripts/HappeningOccur/GetNextHappening.cs
@@ -45,16 +45,13 @@ public class GetNextHappening : MonoBehaviour
     /// <summary>
     /// 다음 이벤트를 읽어옴.
     /// </summary>
-    public void z()
+    public void GetNext()
     {
         if (choiceIng) return;
         txtScripts.Clear(); // 대화 로그 초기화
         txtScriptsIndex = 0; // 대화 로그 번호 초기화
-<<<<<<< Updated upstream
         branchFlag = false;
-=======
-        branchFlag = true;
->>>>>>> Stashed changes
+
 
         HappeningUtils.instance.DebugPrintHappening__(
             HappeningUtils.instance.GetPresentHappening__());

--- a/Assets/02. Scripts/HappeningOccur/GetNextHappening.cs
+++ b/Assets/02. Scripts/HappeningOccur/GetNextHappening.cs
@@ -45,12 +45,16 @@ public class GetNextHappening : MonoBehaviour
     /// <summary>
     /// 다음 이벤트를 읽어옴.
     /// </summary>
-    public void GetNext()
+    public void z()
     {
         if (choiceIng) return;
         txtScripts.Clear(); // 대화 로그 초기화
         txtScriptsIndex = 0; // 대화 로그 번호 초기화
+<<<<<<< Updated upstream
         branchFlag = false;
+=======
+        branchFlag = true;
+>>>>>>> Stashed changes
 
         HappeningUtils.instance.DebugPrintHappening__(
             HappeningUtils.instance.GetPresentHappening__());


### PR DESCRIPTION
1. ChoiceManager.cs에서 IndexOutOfRange 에러 해결
선택지를 불러올 때 IndexOutOfRange가 발생하는 오류 수정
GetNextHappening.cs에서 선택지를 불러올 때 ChoiceManager.cs의 answerList를 초기화하지 않아
선택지 창을 닫기 전에 메인화면으로 돌아왔다가 다시 선택지를 불러옴으로써 이전 선택지 개수 + 현재 선택지 개수로 계산되어 발생하는 오류였음.
GetNextHappening.cs를 수정하여 해결

2. ChoiceManager.cs에서 빠르게 선택지를 선택시 발생하던 에러 해결
선택지 텍스트가 다 나오기 전에 선택지를 클릭할 시 발생하던 오류를 ChoiceManager.cs를 수정하여 해결
clickAvailable (bool 변수)를 사용하여 선택지가 다 나오기 전까지 선택지를 선택하지 못하도록 수정함.
